### PR TITLE
Adjust `intermediateOutputPath` for Embroider when necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,7 @@ Just the same as with vanilla ember-css-modules, but using `.scss` files for you
 ## Configuration
 
 This plugin will configure ember-css-modules so that classes in all `.scss` files in your project will be namespaced. If you need finer-grained control over the treatment of specific aspects of the interplay between CSS Modules and Sass, see the [ember-css-modules preprocessors guide](https://github.com/salsify/ember-css-modules/blob/master/docs/PREPROCESSORS.md).
+
+## Usage with Embroider
+
+For applications, the relative output path from one CSS processor is in a different location with Embroider than with a regular Ember CLI build. If `ember-css-modules-sass` detects that you're running in an application with `@embroider/compat` installed, it will attempt to adjust its `intermediateOutputPath` setting accordingly.

--- a/index.js
+++ b/index.js
@@ -24,12 +24,24 @@ class SassPlugin extends Plugin {
 
   config() {
     return {
-      intermediateOutputPath: this.isForAddon() ? 'addon.scss' : 'app/styles/app.scss',
+      intermediateOutputPath: this._intermediateOutputPath(),
       extension: 'scss',
       postcssOptions: {
         syntax: require('postcss-scss')
       }
     };
+  }
+
+  _intermediateOutputPath() {
+    return this.isForAddon()
+      ? 'addon.scss'
+      : this._hasEmbroider()
+      ? 'app.scss'
+      : 'app/styles/app.scss';
+  }
+
+  _hasEmbroider() {
+    return '@embroider/compat' in (this.parent.pkg.devDependencies || {});
   }
 
   _verifySetup(parent) {


### PR DESCRIPTION
This could also be fixed by manually specifying an `intermediateOutputPath`, but the point of this package is for devs not to have to think about that.

Fixes #8 